### PR TITLE
Deal correctly with ASDF_DIR being different from ASDF_DATA_DIR

### DIFF
--- a/asdf-test.el
+++ b/asdf-test.el
@@ -32,19 +32,20 @@
 (require 'ert)
 
 (ert-deftest asdf-enable-sets-environment-test()
-  (let ((asdf-path "/path-to-asdf"))
+  (let ((asdf-path "/path-to-asdf-data")
+        (asdf-binary "/path-to-asdf-bin/bin/asdf"))
     (asdf-enable)
     (should
-     (string-match-p
-      "\\/path-to-asdf\\/shims:\\/path-to-asdf\\/bin:"
+     (string-prefix-p
+      "/path-to-asdf-data/shims:/path-to-asdf-bin/bin:"
       (getenv "PATH")))
     (should
      (member
-      "/path-to-asdf/shims"
+      "/path-to-asdf-data/shims"
       exec-path))
     (should
      (member
-      "/path-to-asdf/bin"
+      "/path-to-asdf-bin/bin"
       exec-path))))
 
 (ert-deftest asdf-current-test()

--- a/asdf.el
+++ b/asdf.el
@@ -127,12 +127,10 @@ Optionally supply a GIT-URL for git repository to a plugin."
 (defun asdf-enable ()
   "Setup asdf for environment."
   (interactive)
-  (let ((path (substitute-env-vars (concat asdf-path "/shims:" asdf-path "/bin:$PATH"))))
-    (setenv "PATH" path)
-    (setq exec-path
-          (append
-           (split-string-and-unquote path ":")
-           exec-path))))
+  (let ((shims-path (substitute-env-vars (concat asdf-path "/shims")))
+        (bin-path (directory-file-name (file-name-directory (substitute-env-vars asdf-binary)))))
+    (setenv "PATH" (concat shims-path ":" bin-path ":" (getenv "PATH")))
+    (setq exec-path (nconc (list shims-path bin-path) exec-path))))
 
 (provide 'asdf)
 


### PR DESCRIPTION
ASDF may be installed for all users, for example, in `/opt/asdf-vm`. This means that `(concat asdf-path "/bin")` may not exist. ASDF itself deals with this [here](https://github.com/asdf-vm/asdf/blob/711ad991043a1980fa264098f29e78f2ecafd610/asdf.sh#L25-L31). This PR makes it so that the bin-path is extracted from the `asdf-binary` variable.

Also, there was a small bug in the code: appending `(split-string-and-unquote path ":")` with `exec-path` would create duplicate entries.

The `directory-file-name` is not entirely necessary for this to work, but it removes the trailing slash and makes `exec-path` be equal to `(default-value 'exec-path)` (when it hasn't been further modified).

Also, thanks for the package! Was a big help.